### PR TITLE
Updated MPR URLs

### DIFF
--- a/docs/mpr/getting-started.md
+++ b/docs/mpr/getting-started.md
@@ -2,4 +2,4 @@ To use the MPR, you must first have [makedeb](/makedeb/intro.md) installed on yo
 
 The MPR is also designed first and foremost for Debian-based distributions, and there is thus no guarantee on usability for Arch-based systems.
 
-To begin using the MPR, head over to the [MPR homepage](https://mpr.hunterwittenborn.com), and create an account.
+To begin using the MPR, head over to the [MPR homepage](https://{{env.mpr_url}}), and create an account.

--- a/docs/mpr/using-the-mpr/uploading-pkgbuilds.md
+++ b/docs/mpr/using-the-mpr/uploading-pkgbuilds.md
@@ -27,8 +27,8 @@ On a succesful connection, you should get a message similar to such:
 ```
 PTY allocation request failed on channel 0
 Interactive shell is disabled.
-Try `ssh mpr@mpr.hunterwittenborn.com help` for a list of commands.
-Connection to mpr.hunterwittenborn.com closed.
+Try `ssh mpr@{{env.mpr_url}} help` for a list of commands.
+Connection to {{env.mpr_url}} closed.
 ```
 
 ## Uploading your package

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -41,7 +41,7 @@ copyright: Copyright &copy; 2021 Hunter Wittenborn. See the source for copying c
 extra:
   env:
     proget_url: "proget.hunterwittenborn.com"
-    mpr_url: "mpr.hunterwittenborn.com"
+    mpr_url: "mpr.makedeb.org"
     aur_url: "aur.archlinux.org"
     github_url: "github.com"
     site_url: "makedeb.hunterwittenborn.com"


### PR DESCRIPTION
Not 100% sure why not all of the URLs that could have used the env string, but I changed it and updated it to reflect it. Fixes #18 