### PR TITLE
Force amd64 arch on prebuild-mpr debian packages source list

### DIFF
--- a/content/prebuilt-mpr/getting-started.md
+++ b/content/prebuilt-mpr/getting-started.md
@@ -23,7 +23,7 @@ Run the following to set up the APT repository on your system:
 
 ```sh
 curl -q 'https://proget.{{< makedeb_url >}}/debian-feeds/prebuilt-mpr.pub' | gpg --dearmor | sudo tee /usr/share/keyrings/prebuilt-mpr-archive-keyring.gpg 1> /dev/null
-echo "deb [signed-by=/usr/share/keyrings/prebuilt-mpr-archive-keyring.gpg] https://proget.{{< makedeb_url >}} prebuilt-mpr $(lsb_release -cs)" | sudo tee /etc/apt/sources.list.d/prebuilt-mpr.list
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/prebuilt-mpr-archive-keyring.gpg] https://proget.{{< makedeb_url >}} prebuilt-mpr $(lsb_release -cs)" | sudo tee /etc/apt/sources.list.d/prebuilt-mpr.list
 sudo apt update
 ```
 


### PR DESCRIPTION
**Problem**: 

Currently the `prebuilt-mpr` repository seems to only support the `amd64` architecture, however the source list indicated in the documentation does not force the `amd64` architecture, which can lead to an error if your operating system has `dpkg` configured with other architectures (for example, I have Steam installed and it added the `i386` architecture)

I get an error when performing the `sudo apt update`, like

```bash
N: Skipping acquire of configured file 'jammy/binary-i386/Packages' as repository 'https://proget.makedeb.org prebuilt-mpr InRelease' doesn't support architecture 'i386'

```

**Solution:**
A simple way to resolve this is by adding `arch=amd64` as part of the repository's source list, that is, use:

```bash
echo "deb [arch=amd64 signed-by=/usr/share/keyrings/prebuilt-mpr-archive-keyring.gpg] https://proget.{{< makedeb_url >}} prebuilt-mpr $(lsb_release -cs)" | sudo tee /etc/apt/sources.list.d/prebuilt-mpr.list
```

instead of 

```bash
echo "deb [signed-by=/usr/share/keyrings/prebuilt-mpr-archive-keyring.gpg] https://proget.{{< makedeb_url >}} prebuilt-mpr $(lsb_release -cs)" | sudo tee /etc/apt/sources.list.d/prebuilt-mpr.list
```

if in the future prebuild-mpr supports other architectures, add them to the `arch` argument separating them with a comma, like

```bash
echo "deb [arch=amd64,arm,arm64 signed-by=/usr/share/keyrings/prebuilt-mpr-archive-keyring.gpg] https://proget.{{< makedeb_url >}} prebuilt-mpr $(lsb_release -cs)" | sudo tee /etc/apt/sources.list.d/prebuilt-mpr.list
```

To check the active extra architectures in `dpkg`, run

```bash
dpkg --print-foreign-architectures
```

To list all architectures currently supported by dpkg (but not necessarily active) run
```bash
dpkg-architecture --list-known
```