### PR TITLE
Update the docker image links.

### DIFF
--- a/content/installing/docker.md
+++ b/content/installing/docker.md
@@ -14,19 +14,19 @@ Images can be downloaded from the following:
 
 {{< toggle-item class="Stable" show=1 >}}
 ```sh
-proget.{{< makedeb_url >}}/docker/makedeb/makedeb
+ghcr.io/makedeb/makedeb
 ```
 {{< /toggle-item >}}
 
 {{< toggle-item class="Beta" >}}
 ```sh
-proget.{{< makedeb_url >}}/docker/makedeb/makedeb-beta
+ghcr.io/makedeb/makedeb-beta
 ```
 {{< /toggle-item >}}
 
 {{< toggle-item class="Alpha" >}}
 ```sh
-proget.{{< makedeb_url >}}/docker/makedeb/makedeb-alpha
+ghcr.io/makedeb/makedeb-alpha
 ```
 {{< /toggle-item >}}
 
@@ -53,5 +53,5 @@ Images are published for [all currently supported releases of Ubuntu](https://wi
 For example, to pull the beta image with the `ubuntu-bionic` tag, pull the following:
 
 ```
-proget.{{< makedeb_url >}}/docker/makedeb/makedeb-beta:ubuntu-bionic
+ghcr.io/makedeb/makedeb-beta:ubuntu-bionic
 ```


### PR DESCRIPTION
When I try the old links (`proget.makedeb.org/docker/` and `proget.hunterwittenborn.com/docker`) in a Dockerfile, docker couldn't pull the image (gives 403 forbidden). After noticing the images has not been updated since 2023/06, I noticed docker images moved to github packages.